### PR TITLE
Implement timestamp logger with tests

### DIFF
--- a/display_server/__init__.py
+++ b/display_server/__init__.py
@@ -1,0 +1,3 @@
+"""Display server package."""
+
+__all__ = []

--- a/display_server/timestamp_logger.py
+++ b/display_server/timestamp_logger.py
@@ -1,5 +1,43 @@
-"""Log topic timestamps."""
+"""Log topic timestamps.
+
+提供された話題とタイムスタンプを、日付ごとのログファイルに追記する。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Union
+
+# ルートディレクトリの ``logs`` フォルダを指すパス
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
 
 
-def log(topic, timestamp):
-    pass
+def log(topic: str, timestamp: Union[datetime, str]) -> Path:
+    """話題とタイムスタンプをログに書き出す。
+
+    Args:
+        topic: 記録する話題。
+        timestamp: ログに書き出すタイムスタンプ。 ``datetime`` または ISO 形式の文字列。
+
+    Returns:
+        Path: 書き込んだログファイルのパス。
+    """
+
+    # タイムスタンプを ``datetime`` オブジェクトに変換
+    if isinstance(timestamp, str):
+        ts = datetime.fromisoformat(timestamp)
+    else:
+        ts = timestamp
+
+    LOG_DIR.mkdir(exist_ok=True)
+    log_file = LOG_DIR / f"topics_{ts:%Y-%m-%d}.txt"
+    line = f"{ts.isoformat()} - {topic}\n"
+
+    with log_file.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+
+    return log_file
+
+
+__all__ = ["log", "LOG_DIR"]

--- a/tests/test_timestamp_logger.py
+++ b/tests/test_timestamp_logger.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+# ルートディレクトリをパスに追加してパッケージをインポート
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from display_server import timestamp_logger
+
+
+def test_log_creates_file(tmp_path, monkeypatch):
+    # LOG_DIR を一時ディレクトリに切り替え
+    monkeypatch.setattr(timestamp_logger, "LOG_DIR", tmp_path)
+    ts = datetime(2024, 1, 1, 12, 0, 0)
+
+    log_path = timestamp_logger.log("test topic", ts)
+
+    assert log_path.exists()
+    assert log_path.parent == tmp_path
+
+    content = log_path.read_text(encoding="utf-8").strip()
+    assert "test topic" in content
+    assert "2024-01-01T12:00:00" in content


### PR DESCRIPTION
## Summary
- implement timestamp logging utility writing to daily log files
- add unit test for timestamp logger

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ed9464ae0832dbe5f0731815bb83f