### PR TITLE
Improve timestamp logging flexibility

### DIFF
--- a/display_server/timestamp_logger.py
+++ b/display_server/timestamp_logger.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, date
 from pathlib import Path
 from typing import Union
 
@@ -13,12 +13,13 @@ from typing import Union
 LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
 
 
-def log(topic: str, timestamp: Union[datetime, str]) -> Path:
+def log(topic: str, timestamp: Union[datetime, str, date]) -> Path:
     """話題とタイムスタンプをログに書き出す。
 
     Args:
         topic: 記録する話題。
-        timestamp: ログに書き出すタイムスタンプ。 ``datetime`` または ISO 形式の文字列。
+        timestamp: ログに書き出すタイムスタンプ。 ``datetime``、 ``date``、
+            または ISO 形式の文字列。
 
     Returns:
         Path: 書き込んだログファイルのパス。
@@ -27,10 +28,14 @@ def log(topic: str, timestamp: Union[datetime, str]) -> Path:
     # タイムスタンプを ``datetime`` オブジェクトに変換
     if isinstance(timestamp, str):
         ts = datetime.fromisoformat(timestamp)
-    else:
+    elif isinstance(timestamp, datetime):
         ts = timestamp
+    elif isinstance(timestamp, date):
+        ts = datetime.combine(timestamp, datetime.min.time())
+    else:  # pragma: no cover - 型チェック用
+        raise TypeError("timestamp must be datetime, date, or ISO format string")
 
-    LOG_DIR.mkdir(exist_ok=True)
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = LOG_DIR / f"topics_{ts:%Y-%m-%d}.txt"
     line = f"{ts.isoformat()} - {topic}\n"
 


### PR DESCRIPTION
## Summary
- allow `timestamp_logger.log` to accept `date` and ISO strings
- ensure log directories are created recursively

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0fe5f914832dab450def4f69a905