### PR TITLE
Add configurable topic similarity threshold

### DIFF
--- a/display_server/config.py
+++ b/display_server/config.py
@@ -1,4 +1,8 @@
 """Configuration parameters for the display server."""
 
-# Placeholder for configuration settings
+# 話題検出のしきい値（Jaccard係数）。
+# 値が小さいほど話題の切り替わりが起きにくくなる。
+TOPIC_SIMILARITY_THRESHOLD: float = 0.5
+
+__all__ = ["TOPIC_SIMILARITY_THRESHOLD"]
 

--- a/display_server/main.py
+++ b/display_server/main.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from flask import Flask, Response, request, render_template, jsonify
 
-from . import transcriber, topic_detector, timestamp_logger
+from . import transcriber, topic_detector, timestamp_logger, config
 
 app = Flask(__name__)
 
@@ -39,7 +39,9 @@ def submit() -> Response:
     audio = request.data or request.form.get("text", "")
     text = transcriber.transcribe(audio)
 
-    if topic_detector.detect(_previous_text, text):
+    if topic_detector.detect(
+        _previous_text, text, threshold=config.TOPIC_SIMILARITY_THRESHOLD
+    ):
         _current_topic = text
         timestamp_logger.log(_current_topic, datetime.utcnow())
 

--- a/tests/test_submit_threshold.py
+++ b/tests/test_submit_threshold.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from display_server import config, timestamp_logger
+import display_server.main as main_module
+
+
+def test_submit_respects_config_threshold(tmp_path, monkeypatch):
+    monkeypatch.setattr(timestamp_logger, "LOG_DIR", tmp_path)
+    monkeypatch.setattr(config, "TOPIC_SIMILARITY_THRESHOLD", 0.9)
+
+    client = main_module.app.test_client()
+    main_module._current_topic = ""
+    main_module._previous_text = None
+
+    client.post("/submit", data=b"hello world")
+    client.post("/submit", data=b"hello world again")
+
+    res = client.get("/topic")
+    assert res.get_json()["topic"] == "hello world again"
+
+    log_files = list(tmp_path.glob("topics_*.txt"))
+    assert len(log_files) == 1
+    lines = log_files[0].read_text(encoding="utf-8").strip().splitlines()
+    assert lines[0].endswith("hello world")
+    assert lines[1].endswith("hello world again")


### PR DESCRIPTION
## Summary
- make topic change threshold configurable via display_server.config
- apply configurable threshold in submit route
- test submit route respects configured threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f11b7ce6c832d8e60145387677659