### PR TITLE
Refactor topic state storage to Flask config

### DIFF
--- a/tests/test_submit_threshold.py
+++ b/tests/test_submit_threshold.py
@@ -14,8 +14,8 @@ def test_submit_respects_config_threshold(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "TOPIC_SIMILARITY_THRESHOLD", 0.9)
 
     client = main_module.app.test_client()
-    main_module._current_topic = ""
-    main_module._previous_text = None
+    main_module.app.config["CURRENT_TOPIC"] = ""
+    main_module.app.config["PREVIOUS_TEXT"] = None
 
     client.post("/submit", data=b"hello world")
     client.post("/submit", data=b"hello world again")


### PR DESCRIPTION
## Summary
- use `app.config` for current topic and previous text to avoid module-level globals
- update tests to work with Flask config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f51ed6e5c832d93cf02fe0a5dacb8