### PR TITLE
Handle text submissions in Flask endpoint

### DIFF
--- a/display_server/main.py
+++ b/display_server/main.py
@@ -35,8 +35,16 @@ def topic() -> Response:
 @app.route("/submit", methods=["POST"])
 def submit() -> Response:
     """音声(テキスト)を受け取り、話題が変われば更新してログを残す."""
-    audio = request.data or request.form.get("text", "")
-    text = transcriber.transcribe(audio)
+    if "text" in request.form:
+        raw = request.form["text"]
+    else:
+        json_payload = request.get_json(silent=True) or {}
+        if "text" in json_payload:
+            raw = json_payload["text"]
+        else:
+            raw = request.get_data()
+
+    text = transcriber.transcribe(raw)
 
     previous = app.config.get("PREVIOUS_TEXT")
 

--- a/tests/test_submit_form.py
+++ b/tests/test_submit_form.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from display_server import timestamp_logger
+import display_server.main as main_module
+
+
+def test_submit_accepts_form_text(tmp_path, monkeypatch):
+    monkeypatch.setattr(timestamp_logger, "LOG_DIR", tmp_path)
+
+    client = main_module.app.test_client()
+    main_module.app.config["CURRENT_TOPIC"] = ""
+    main_module.app.config["PREVIOUS_TEXT"] = None
+
+    client.post("/submit", data={"text": "form topic"})
+
+    res = client.get("/topic")
+    assert res.get_json()["topic"] == "form topic"
+
+    log_files = list(tmp_path.glob("topics_*.txt"))
+    assert len(log_files) == 1
+    content = log_files[0].read_text(encoding="utf-8").strip()
+    assert content.endswith("form topic")


### PR DESCRIPTION
## Summary
- support text submissions via form or JSON in `/submit`
- add regression test covering form-based text submissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f52ccd3ac832d920316838b113041