### PR TITLE
Sanitize newlines in topic logger entries

### DIFF
--- a/display_server/timestamp_logger.py
+++ b/display_server/timestamp_logger.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime, date
 from pathlib import Path
+import re
 from typing import Union
 
 # ルートディレクトリの ``logs`` フォルダを指すパス
@@ -35,9 +36,12 @@ def log(topic: str, timestamp: Union[datetime, str, date]) -> Path:
     else:  # pragma: no cover - 型チェック用
         raise TypeError("timestamp must be datetime, date, or ISO format string")
 
+    # 改行文字をスペースに置換してログを1行に保つ
+    sanitized = re.sub(r"[\r\n]+", " ", topic)
+
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_file = LOG_DIR / f"topics_{ts:%Y-%m-%d}.txt"
-    line = f"{ts.isoformat()} - {topic}\n"
+    line = f"{ts.isoformat()} - {sanitized}\n"
 
     with log_file.open("a", encoding="utf-8") as fh:
         fh.write(line)

--- a/tests/test_timestamp_logger.py
+++ b/tests/test_timestamp_logger.py
@@ -23,3 +23,15 @@ def test_log_creates_file(tmp_path, monkeypatch):
     content = log_path.read_text(encoding="utf-8").strip()
     assert "test topic" in content
     assert "2024-01-01T12:00:00" in content
+
+
+def test_log_sanitizes_newlines(tmp_path, monkeypatch):
+    monkeypatch.setattr(timestamp_logger, "LOG_DIR", tmp_path)
+    ts = datetime(2024, 1, 1, 0, 0, 0)
+
+    log_path = timestamp_logger.log("line1\nline2\r\nline3", ts)
+
+    content = log_path.read_text(encoding="utf-8").strip()
+    assert content.endswith("line1 line2 line3")
+    assert "\n" not in content
+    assert "\r" not in content


### PR DESCRIPTION
## Summary
- ensure log entries replace newline characters with spaces
- test newline sanitization in timestamp logger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f53c53df4832da0b3a53ecd3a111a