### PR TITLE
feat: stream topics via server-sent events

### DIFF
--- a/display_server/main.py
+++ b/display_server/main.py
@@ -7,6 +7,8 @@ Flaskベースの簡易サーバーを提供し、POSTされたテキストか�
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import time
+from typing import Iterator
 
 from flask import Flask, Response, request, render_template, jsonify
 
@@ -30,6 +32,22 @@ def index() -> str:
 def topic() -> Response:
     """現在の話題をJSON形式で返す."""
     return jsonify({"topic": app.config.get("CURRENT_TOPIC", "")})
+
+
+@app.route("/topic-stream")
+def topic_stream() -> Response:
+    """現在の話題を Server-Sent Events で配信する."""
+
+    def event_stream() -> Iterator[str]:
+        last_sent: str | None = None
+        while True:
+            topic = app.config.get("CURRENT_TOPIC", "")
+            if topic != last_sent:
+                yield f"data: {topic}\n\n"
+                last_sent = topic
+            time.sleep(0.5)
+
+    return Response(event_stream(), mimetype="text/event-stream")
 
 
 @app.route("/submit", methods=["POST"])

--- a/templates/display.html
+++ b/templates/display.html
@@ -5,13 +5,13 @@
     <link rel="stylesheet" href="/static/css/style.css">
     <title>Display</title>
     <script>
-        async function fetchTopic() {
-            const res = await fetch("/topic");
-            const data = await res.json();
-            document.getElementById("topic_box").textContent = data.topic || "";
-        }
-        setInterval(fetchTopic, 1000);
-        window.addEventListener("load", fetchTopic);
+        window.addEventListener("load", () => {
+            const box = document.getElementById("topic_box");
+            const source = new EventSource("/topic-stream");
+            source.onmessage = (e) => {
+                box.textContent = e.data || "";
+            };
+        });
     </script>
 </head>
 <body>

--- a/tests/test_topic_stream.py
+++ b/tests/test_topic_stream.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+import display_server.main as main_module
+from display_server import timestamp_logger
+
+
+def test_topic_stream_emits_updates(tmp_path, monkeypatch):
+    monkeypatch.setattr(timestamp_logger, "LOG_DIR", tmp_path)
+    client = main_module.app.test_client()
+    main_module.app.config["CURRENT_TOPIC"] = ""
+    main_module.app.config["PREVIOUS_TEXT"] = None
+
+    client.post("/submit", data={"text": "stream topic"})
+
+    with client.get("/topic-stream") as resp:
+        event = next(resp.response).decode("utf-8").strip()
+        assert event == "data: stream topic"


### PR DESCRIPTION
## Summary
- deliver current topic via new `/topic-stream` SSE endpoint
- update display page to subscribe with `EventSource`
- add regression test for streaming API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f54b8439c832dab8d17d6443d6b30