### PR TITLE
Add semantic topic detection, Whisper transcription, and PyQt CSS editor

### DIFF
--- a/css_editor/editor.py
+++ b/css_editor/editor.py
@@ -1,31 +1,89 @@
-"""GUI editor for modifying CSS styles.
-
-本来は ``PyQt5`` を用いたGUIエディターを提供する予定だが、テスト
-環境ではGUIライブラリを利用できないため、ここでは設定ファイルを
-標準入力から読み込み ``static/css/style.css`` へ保存する簡易的な
-CLI ベースの実装を提供する。"""
-
 from __future__ import annotations
 
-from pathlib import Path
-import sys
+"""PyQt5 based CSS style editor with preview and theme/font selection."""
 
+from pathlib import Path
+from typing import Optional
+
+from PyQt5.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QFontComboBox,
+    QLabel,
+    QMainWindow,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+from PyQt5.QtCore import Qt
 
 CSS_PATH = Path(__file__).resolve().parents[1] / "static" / "css" / "style.css"
+THEMES_DIR = Path(__file__).resolve().with_name("themes")
+
+
+class CSSEditor(QMainWindow):
+    """Simple editor window."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("CSS Editor")
+
+        self.theme_box = QComboBox()
+        self.theme_box.addItems([p.name for p in THEMES_DIR.glob("*.css")])
+        self.theme_box.currentTextChanged.connect(self.load_theme)
+
+        self.font_box = QFontComboBox()
+        self.font_box.currentFontChanged.connect(self.update_preview)
+
+        self.text_edit = QTextEdit()
+        self.preview = QLabel("Preview")
+        self.preview.setAlignment(Qt.AlignCenter)
+        self.save_button = QPushButton("Save")
+        self.save_button.clicked.connect(self.save_css)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.theme_box)
+        layout.addWidget(self.font_box)
+        layout.addWidget(self.text_edit)
+        layout.addWidget(self.preview)
+        layout.addWidget(self.save_button)
+
+        container = QWidget()
+        container.setLayout(layout)
+        self.setCentralWidget(container)
+
+        self.load_theme(self.theme_box.currentText())
+
+    def load_theme(self, name: str) -> None:
+        path = THEMES_DIR / name
+        if path.exists():
+            css = path.read_text(encoding="utf-8")
+            self.text_edit.setPlainText(css)
+            self.update_preview()
+
+    def update_preview(self) -> None:
+        css = self.text_edit.toPlainText()
+        font = self.font_box.currentFont()
+        self.preview.setStyleSheet(css)
+        self.preview.setFont(font)
+
+    def save_css(self) -> None:
+        CSS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        CSS_PATH.write_text(self.text_edit.toPlainText(), encoding="utf-8")
 
 
 def launch() -> None:
-    """Run the minimal CSS editor.
+    """Launch the editor application."""
 
-    標準入力からCSS文字列を読み取り、 ``style.css`` に保存する。
-    GUI を使えない環境でもスタイル変更が行えるようにするための
-    簡易実装である。
-    """
+    import os
 
-    css = sys.stdin.read()
-    CSS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CSS_PATH.write_text(css, encoding="utf-8")
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    editor = CSSEditor()
+    editor.show()
+    app.exec_()
 
 
-if __name__ == "__main__":  # pragma: no cover - CLI 実行時のみ
+if __name__ == "__main__":  # pragma: no cover
     launch()

--- a/display_server/config.py
+++ b/display_server/config.py
@@ -1,8 +1,25 @@
 """Configuration parameters for the display server."""
 
-# 話題検出のしきい値（Jaccard係数）。
-# 値が小さいほど話題の切り替わりが起きにくくなる。
-TOPIC_SIMILARITY_THRESHOLD: float = 0.5
+from __future__ import annotations
 
-__all__ = ["TOPIC_SIMILARITY_THRESHOLD"]
+import os
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, default))
+    except ValueError:
+        return default
+
+
+# 話題検出のしきい値。値が小さいほど話題の切り替わりが起きにくくなる。
+TOPIC_SIMILARITY_THRESHOLD: float = _env_float(
+    "TOPIC_SIMILARITY_THRESHOLD", 0.5
+)
+
+# ログレベルを環境変数から設定できるようにする。
+LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
+
+
+__all__ = ["TOPIC_SIMILARITY_THRESHOLD", "LOG_LEVEL"]
 

--- a/display_server/state.py
+++ b/display_server/state.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Thread-safe application state storage."""
+
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Optional
+
+
+@dataclass
+class TopicState:
+    """Represent mutable state for current and previous topics."""
+
+    current_topic: str = ""
+    previous_text: Optional[str] = None
+    lock: Lock = field(default_factory=Lock, repr=False)
+
+
+_state: TopicState | None = None
+
+
+def get_state() -> TopicState:
+    """Return a process-wide :class:`TopicState` instance.
+
+    The object is created lazily to avoid issues during import time and is
+    protected by a ``Lock`` to allow safe updates from concurrent requests.
+    """
+
+    global _state
+    if _state is None:
+        _state = TopicState()
+    return _state
+
+
+__all__ = ["TopicState", "get_state"]

--- a/display_server/timestamp_logger.py
+++ b/display_server/timestamp_logger.py
@@ -9,6 +9,7 @@ from datetime import datetime, date
 from pathlib import Path
 import re
 from typing import Union
+import logging
 
 # ルートディレクトリの ``logs`` フォルダを指すパス
 LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
@@ -46,6 +47,7 @@ def log(topic: str, timestamp: Union[datetime, str, date]) -> Path:
     with log_file.open("a", encoding="utf-8") as fh:
         fh.write(line)
 
+    logging.getLogger(__name__).info("logged topic: %s", sanitized)
     return log_file
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
-flask
+Flask==2.3.3
+PyQt5==5.15.10
+scikit-learn==1.3.2
+openai-whisper==20231111
+pytest==7.4.4
+pytest-qt==4.3.1

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -1,0 +1,14 @@
+import importlib
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+
+def test_threshold_env(monkeypatch):
+    monkeypatch.setenv("TOPIC_SIMILARITY_THRESHOLD", "0.1")
+    import display_server.config as config
+    importlib.reload(config)
+    assert config.TOPIC_SIMILARITY_THRESHOLD == 0.1

--- a/tests/test_css_editor.py
+++ b/tests/test_css_editor.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtWidgets import QApplication
+
+from css_editor.editor import CSSEditor, CSS_PATH
+
+
+def test_save_css(tmp_path, monkeypatch):
+    monkeypatch.setattr('css_editor.editor.CSS_PATH', tmp_path / 'style.css')
+    app = QApplication.instance() or QApplication([])
+    editor = CSSEditor()
+    editor.text_edit.setPlainText("body { color: red; }")
+    editor.save_css()
+    content = (tmp_path / 'style.css').read_text(encoding='utf-8')
+    assert "color: red" in content

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import sys
+import base64
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from display_server import transcriber
+
+
+def test_transcribe_fallback(monkeypatch):
+    # Avoid loading whisper model
+    monkeypatch.setattr(transcriber, "_load_model", lambda: None)
+    data = b"\xff\xff"
+    text = transcriber.transcribe(data)
+    assert text == base64.b64encode(data).decode("ascii")
+
+
+def test_transcribe_string(monkeypatch):
+    assert transcriber.transcribe("hello") == "hello"


### PR DESCRIPTION
## Summary
- improve state management and logging for the Flask server
- switch topic detection to TF-IDF cosine similarity
- add optional Whisper transcription and PyQt-based CSS editor

## Testing
- `pip install Flask==2.3.3 PyQt5==5.15.10 scikit-learn==1.3.2 pytest==7.4.4 pytest-qt==4.3.1` (failed: 403 Forbidden)
- `pytest` (failed: ModuleNotFoundError: No module named 'PyQt5')

------
https://chatgpt.com/codex/tasks/task_e_688f558ee9e4832d90b884f012637431