### PR TITLE
Add microphone input support using SpeechRecognition

### DIFF
--- a/display_server/audio_listener.py
+++ b/display_server/audio_listener.py
@@ -1,10 +1,9 @@
 """Handle audio input for transcription.
 
 このモジュールは音声入力を抽象化し、呼び出し元に生の音声
-バイト列を返す簡易的なユーティリティを提供する。実際のマイク
-入力などは扱わず、ファイルパスやファイルオブジェクトからの
-読み込みに対応している。テスト環境でも利用しやすい実装として
-いる。
+バイト列を返すユーティリティを提供する。従来はファイルや
+標準入力のみを扱っていたが、`speech_recognition` ライブラリが
+利用可能な場合はマイク入力も取得できるようになった。
 """
 
 from __future__ import annotations
@@ -12,6 +11,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import BinaryIO, Optional, Union
 import sys
+
+try:  # pragma: no cover - optional dependency
+    import speech_recognition as sr
+except Exception:  # pragma: no cover - library not installed
+    sr = None
 
 
 SourceType = Optional[Union[str, Path, BinaryIO]]
@@ -24,15 +28,25 @@ def listen(source: SourceType = None) -> bytes:
         source: 音声データを取得する元。 ``None`` の場合は ``stdin`` から
             読み込む。文字列または ``Path`` の場合はそのパスのファイルを
             バイナリモードで開いて内容を読み込む。ファイルオブジェクトが
-            渡された場合は ``read()`` で全データを取得する。
+            渡された場合は ``read()`` で全データを取得する。文字列で
+            ``"microphone"`` が指定された場合は、デフォルトマイクから
+            音声を録音して返す。
 
     Returns:
         bytes: 読み込まれた生の音声データ。
     """
 
-    if source is None:
+    if source in (None, "stdin"):
         # スタンドアロンでも扱いやすいよう、標準入力から読み込む。
         return sys.stdin.buffer.read()
+
+    if source == "microphone":
+        if sr is None:
+            raise RuntimeError("speech_recognition is not available")
+        recognizer = sr.Recognizer()
+        with sr.Microphone() as mic:  # pragma: no cover - requires hardware
+            audio = recognizer.listen(mic)
+        return audio.get_wav_data()
 
     if isinstance(source, (str, Path)):
         with open(source, "rb") as fh:  # pragma: no cover - ファイル操作のため

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scikit-learn==1.3.2
 openai-whisper==20231111
 pytest==7.4.4
 pytest-qt==4.3.1
+SpeechRecognition==3.10.0

--- a/tests/test_audio_listener.py
+++ b/tests/test_audio_listener.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from display_server import audio_listener
+
+
+def test_listen_microphone(monkeypatch):
+    class DummyAudio:
+        def get_wav_data(self):
+            return b"abc"
+
+    class DummyRecognizer:
+        def listen(self, source):
+            return DummyAudio()
+
+    class DummyMic:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    dummy_sr = types.SimpleNamespace(Recognizer=lambda: DummyRecognizer(), Microphone=DummyMic)
+    monkeypatch.setattr(audio_listener, "sr", dummy_sr)
+    assert audio_listener.listen("microphone") == b"abc"


### PR DESCRIPTION
## Summary
- use SpeechRecognition to capture audio from microphone
- add SpeechRecognition dependency
- add unit test for microphone listener

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689013080a88832d9d9172d8ade7f031