### PR TITLE
feat: add topic streaming

### DIFF
--- a/templates/display.html
+++ b/templates/display.html
@@ -5,13 +5,12 @@
     <link rel="stylesheet" href="/static/css/style.css">
     <title>Display</title>
     <script>
-        async function fetchTopic() {
-            const res = await fetch("/topic");
-            const data = await res.json();
-            document.getElementById("topic_box").textContent = data.topic || "";
-        }
-        setInterval(fetchTopic, 1000);
-        window.addEventListener("load", fetchTopic);
+        window.addEventListener("load", () => {
+            const es = new EventSource("/stream");
+            es.onmessage = (e) => {
+                document.getElementById("topic_box").textContent = e.data || "";
+            };
+        });
     </script>
 </head>
 <body>

--- a/tests/test_stream_endpoint.py
+++ b/tests/test_stream_endpoint.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from display_server import timestamp_logger
+import display_server.main as main_module
+
+
+def test_stream_provides_updates(tmp_path, monkeypatch):
+    monkeypatch.setattr(timestamp_logger, "LOG_DIR", tmp_path)
+
+    # initialize state
+    st = main_module.state_module.get_state()
+    st.current_topic = "initial"
+    st.previous_text = None
+
+    client = main_module.app.test_client()
+
+    res = client.get("/stream")
+    first = next(res.response).decode().strip()
+    assert first == "data: initial"
+
+    client.post("/submit", data={"text": "next"})
+    second = next(res.response).decode().strip()
+    assert second == "data: next"
+
+    res.close()


### PR DESCRIPTION
## Summary
- serve current topic via SSE at `/stream`
- update display template to consume SSE
- test SSE endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689023c991e0832d92a2190031d02002