### PR TITLE
Add PyInstaller specs and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,16 @@ python -m display_server.main
 ```
 python -m css_editor.editor < my_style.css
 ```
+
+## ビルド
+
+PyInstaller を使用して実行ファイルを作成できます。
+
+```
+pip install pyinstaller
+pip install -r requirements.txt
+pyinstaller run_display.spec
+pyinstaller run_editor.spec
+```
+
+`dist/` ディレクトリにそれぞれの実行ファイルが生成されます。

--- a/run_display.spec
+++ b/run_display.spec
@@ -1,0 +1,55 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+hidden_imports = [
+    'Flask',
+    'PyQt5',
+    'sklearn',
+    'whisper',
+    'pytest',
+    'pytestqt',
+    'speech_recognition',
+]
+
+
+a = Analysis(
+    ['display_server/main.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[
+        ('templates/*.html', 'templates'),
+        ('static/css/*.css', 'static/css'),
+    ],
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='run_display',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='run_display',
+)

--- a/run_editor.spec
+++ b/run_editor.spec
@@ -1,0 +1,55 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+hidden_imports = [
+    'Flask',
+    'PyQt5',
+    'sklearn',
+    'whisper',
+    'pytest',
+    'pytestqt',
+    'speech_recognition',
+]
+
+a = Analysis(
+    ['css_editor/editor.py'],
+    pathex=['.'],
+    binaries=[],
+    datas=[
+        ('css_editor/themes/*.css', 'css_editor/themes'),
+        ('css_editor/assets/*', 'css_editor/assets'),
+        ('static/css/*.css', 'static/css'),
+    ],
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='run_editor',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='run_editor',
+)


### PR DESCRIPTION
## Summary
- add PyInstaller spec for display server
- add PyInstaller spec for CSS editor
- document build steps using PyInstaller

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai-whisper==20231111)*
- `pip install Flask==2.3.3 PyQt5==5.15.10 scikit-learn==1.3.2 pytest==7.4.4 pytest-qt==4.3.1 SpeechRecognition==3.10.0`
- `pip install openai-whisper==20231105` *(fails: Could not find a version that satisfies the requirement triton==2.0.0)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689028b046a0832db1a620640a49de33