### PR TITLE
docs: describe GUI usage for CSS editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,17 @@ python -m display_server.main
 
 ### CSSエディター
 
-標準入力からCSSを読み取り `static/css/style.css` に保存します。
+PyQt5製のGUIでCSSを編集します。以下のコマンドでエディターを起動します。
 
 ```
-python -m css_editor.editor < my_style.css
+python -m css_editor.editor
 ```
+
+1. 起動後、テーマ選択ドロップダウンでテンプレートを読み込みます。
+2. フォントやCSSを編集すると右側のプレビューに即時反映されます。
+3. 「保存」ボタンで `static/css/style.css` に書き込みます。
+
+> 補足: CLIからCSSファイルを読み込ませる場合は `python -m css_editor.editor < my_style.css` を実行できます。
 
 ## ビルド
 


### PR DESCRIPTION
## Summary
- rewrite CSS editor section to use the GUI editor
- document `python -m css_editor.editor` launch command and preview/theme features
- move CLI usage into a supplementary note

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902aa7b904832d984750e4d7082459