### PR TITLE
feat: simplify startup with two entry scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Flaskサーバーと簡易CSSエディターからなるツール。POSTされ�
 ### サーバー
 
 ```
-python -m display_server.main
+python run_display.py
 ```
 
 - `POST /submit` にテキストを送信すると話題が更新され、必要に応じて `logs/` にタイムスタンプ付きで記録されます。
@@ -18,14 +18,14 @@ python -m display_server.main
 PyQt5製のGUIでCSSを編集します。以下のコマンドでエディターを起動します。
 
 ```
-python -m css_editor.editor
+python run_editor.py
 ```
 
 1. 起動後、テーマ選択ドロップダウンでテンプレートを読み込みます。
 2. フォントやCSSを編集すると右側のプレビューに即時反映されます。
 3. 「保存」ボタンで `static/css/style.css` に書き込みます。
 
-> 補足: CLIからCSSファイルを読み込ませる場合は `python -m css_editor.editor < my_style.css` を実行できます。
+> 補足: CLIからCSSファイルを読み込ませる場合は `python run_editor.py < my_style.css` を実行できます。
 
 ## ビルド
 

--- a/run_display.py
+++ b/run_display.py
@@ -1,0 +1,4 @@
+from display_server.main import main
+
+if __name__ == '__main__':
+    main()

--- a/run_editor.py
+++ b/run_editor.py
@@ -1,0 +1,4 @@
+from css_editor.editor import launch
+
+if __name__ == '__main__':
+    launch()


### PR DESCRIPTION
## Summary
- add top-level scripts `run_display.py` and `run_editor.py` for compact startup
- document new launch commands in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890dd7bff50832d9f3171683a8bb26f